### PR TITLE
Add node engine for heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "version": "0.1.0",
   "devDependencies": {
     "webpack-dev-server": "^4.11.1"
+  },
+  "engines": {
+    "node": "14.17.0"
   }
 }


### PR DESCRIPTION
Add node engine to set the node version to use in Heroku to fix node-sass build error.